### PR TITLE
Add Nir Levy content to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,13 +38,117 @@ const repoLink = 'https://github.com/cloudflare/templates/tree/main/saas-admin-t
     <div class="flex flex-col items-center justify-center gap-4 py-20 px-8">
       <h1 class="text-5xl font-bold">SaaS Admin Template</h1>
       <p class="text-xl text-muted-foreground">Manage a SaaS application - customers, subscriptions - using Cloudflare Workers and D1.</p>
-      <div class="flex flex gap-4 mt-4">
+
+      <!-- Nir Levy biography section -->
+      <section class="mt-8 space-y-4 text-center">
+        <h2 class="text-4xl font-bold">Nir Levy of Atlanta, Georgia</h2>
+        <p>Hey, thank you for snooping! 🔎 Please enjoy reading about me.</p>
+        <ul class="list-disc pl-5 text-left inline-block">
+          <li>My name is Nir (pronounced like the opposite of far) 😀</li>
+          <li>
+            My email is
+            <a href="mailto:NNLevy@gmail.com" class="underline">NNLevy@gmail.com</a>
+          </li>
+          <li>Text me at <strong>(785) LEVY-NIR</strong> | (785) 538-9647</li>
+          <li>
+            <a href="https://www.ajc.org/lftfacilitators" class="underline">You can read my bio here</a>.
+          </li>
+        </ul>
+
+        <h3 class="text-2xl font-semibold">Watch me pitch the magic of Friday:</h3>
+        <p>
+          <a
+            href="https://www.youtube.com/watch?list=PLzDQun_hlbVWmNdkNKviDwcVIvzbciK_7&v=TOztyEEH-x8&feature=youtu.be"
+            class="underline"
+            >OneTable FIN Propel Pitch</a
+          >
+        </p>
+
+        <h3 class="text-xl font-semibold">News featuring my photography</h3>
+        <ul class="list-disc pl-5 text-left inline-block">
+          <li>
+            <a href="https://www.jns.org/opinion/dont-believe-the-jimmy-carter-revisionists/" class="underline">Don’t believe the Jimmy Carter revisionists</a>
+          </li>
+          <li>
+            <a href="https://www.psychologytoday.com/us/blog/hidden-motives/201510/what-is-democracy-0" class="underline">What Is a Democracy?</a>
+          </li>
+          <li>
+            <a href="https://thegeorgiasun.com/2022/07/18/the-latest-on-the-court-battle-over-georgias-abortion-law/" class="underline">The latest on the court battle over Georgia's abortion law | The Georgia Sun</a>
+          </li>
+          <li>
+            <a href="https://www.grunge.com/1206904/the-tragic-2015-death-of-jimmy-carters-grandson/" class="underline">The Tragic 2015 Death Of Jimmy Carter's Grandson - Grunge</a>
+          </li>
+        </ul>
+
+        <h3 class="text-xl font-semibold">on social</h3>
+        <p>
+          <a href="https://twitter.com/quizbiz?lang=en" class="underline">quizbiz</a>
+        </p>
+
+        <h3 class="text-xl font-semibold">News featuring my businesses</h3>
+        <ul class="list-disc pl-5 text-left inline-block">
+          <li>
+            <a href="https://news.emory.edu/stories/2012/09/er_emory_bubble/campus.html" class="underline">Emory Bubble seeks to connect campus for students | Emory University | Atlanta GA</a>
+          </li>
+          <li>
+            <a href="https://www.nytimes.com/2012/07/20/education/edlife/campus-incubators-are-on-the-rise-as-colleges-encourage-student-start-ups.html" class="underline">Got the Next Great Idea? (Published 2012)</a>
+          </li>
+        </ul>
+
+        <h3 class="text-xl font-semibold">in podcasts</h3>
+        <p>
+          <a href="https://podcasts.apple.com/gb/podcast/episode-316-whats-for-dinner-this-shabbat-nir-levy/id1088015938?i=1000552897511" class="underline">‎Judaism Unbound: Episode 316: What's for Dinner this Shabbat? - Nir Levy, Annie Prusky on Apple Podcasts</a>
+        </p>
+
+        <h3 class="text-xl font-semibold">News featuring my nonprofit work</h3>
+        <ul class="list-disc pl-5 text-left inline-block">
+          <li>
+            <a href="https://www.leadingedge.org/post/bmi-cohort-7-announcement" class="underline">Meet the 40 Board Members Chosen as Cohort 7 of the Board Member Institute | Leading Edge</a>
+          </li>
+          <li>
+            <a href="https://www.upstartlab.org/announcing-2022-change-accelerator-participants/" class="underline">Announcing 2022 Change Accelerator Participants - UpStart</a>
+          </li>
+        </ul>
+
+        <h3 class="text-xl font-semibold">Passion Projects and Side Hustles</h3>
+        <ul class="list-disc pl-5 text-left inline-block">
+          <li>
+            <a href="https://www.shutterstock.com/en/g/nir+levy?rid=2863" class="underline">Stock Photo and Image Portfolio by Nir Levy | Shutterstock</a>
+          </li>
+        </ul>
+        <p>
+          Since 2005, I’ve referred 156 other photographers and sold 9,635 pictures generating a passive income stream. Total revenue: $4,527.75.
+        </p>
+        <p>
+          <a href="https://medium.com/@quizbiz/impressionist-artist-w-chapman-d8e015988c8e" class="underline">Impressionist Artist W. Chapman</a>
+        </p>
+        <p>
+          Thanks to a single successful blog post about art I found in a thrift store, I was invited to the Medium Partner Program paying about $2.50 per 10k views. Total revenue: Under $100
+        </p>
+        <p>
+          <a href="http://www.blipfolio.com/nir/bar-bat-mitzvah-photography" class="underline">Nir Levy Event Photography in Atlanta, Georgia</a>
+        </p>
+        <p>My online photo gallery.</p>
+        <p>
+          <a href="https://calendly.com/nir-ajc" class="underline">Nir Levy</a>
+        </p>
+        <p>Set up a time to meet with me.</p>
+        <p>
+          <a href="http://growth.business" class="underline">Growth.business | Grow Your Business</a>
+        </p>
+        <p>
+          I build websites that solve complex challenges for consumers and business owners with resources.
+        </p>
+      </section>
+
+      <div class="flex flex gap-4 mt-8">
         <a class={buttonVariants()} href="/admin">
           <LayoutDashboard /> Go to admin
         </a>
         <a class={buttonVariants({ variant: 'outline' })} href={repoLink}>
           <Github /> View on GitHub
         </a>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore SaaS Admin Template heading
- incorporate Nir Levy biography and related links under main content

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f692fc8d083239ee42f87f266bd12